### PR TITLE
Align Selected Text

### DIFF
--- a/Align Selected Text.ahk
+++ b/Align Selected Text.ahk
@@ -8,10 +8,10 @@ if (!sel:=sc.getseltext()){
 matchStr:=x.call["InputBox",sc.sc,"Align Text","Align text by:",settings.get("//CodeAlign/@last",":=")]
 if (!matchStr)
 	ExitApp
-settings.ssn("//CodeAlign/@last").text:=matchStr,settings.save(1),i:=tpos:=sc.2166(sc.2143),pbot:=sc.2166(sc.2145),ind:=settings.get("//tab",5),sc.2025(sc.2143)
+settings.ssn("//CodeAlign/@last").text:=matchStr,settings.save(1),i:=tpos:=sc.2166(sc.2143),pbot:=sc.2166(sc.2145),ind:=settings.get("//tab",5),hasInd:=0,sc.2025(sc.2143)
 while (i<=pbot){
 	if (found:=InStr(sc.getline(i),matchStr))
-		found>maxPos?(maxPos:=found,maxPosL:=i):"",(lInd:=sc.2127(i))>maxInd?(maxInd:=lInd,maxIndL:=i):""
+		hasInd:=hasInd?1:(lInd&&lInd!=sc.2127(i)?1:0), lInd:=sc.2127(i), found>maxPos?(maxPos:=found, maxPosL:=i):"", (lInd>maxInd||(lInd=maxInd&&i=maxPosL))?(maxInd:=lInd, maxIndL:=i):""
 	i++
 }
 if (maxPos>1){
@@ -22,7 +22,7 @@ if (maxPos>1){
 			Loop,% (((maxInd-lInd)//ind)*ind)-1
 				str.=" "
 		if (found:=InStr(sc.getline(i),matchStr)){
-			Loop,% maxPos-found-(maxInd?(maxPosL!=maxIndL?ind-1:0):0)
+			Loop,% maxPos-found-(hasInd?(maxPosL!=maxIndL?ind-1:0):0)
 				str.=" "
 			sc.2190(cFound:=sc.2167(i)+found-1),sc.2192(cFound),len:=StrLen(str),sc.2194(len,str)
 		}

--- a/Index.xml
+++ b/Index.xml
@@ -1,6 +1,6 @@
 <plugins>
 	<plugin author="maestrith" name="Additional Publish" description="Used to add code that is not included with #Include" date="20150901013435"></plugin>
-	<plugin author="number1nub" name="Align Selected Text" description="Align Selected Text" date="20150918200243" version="1"></plugin>
+	<plugin author="number1nub" name="Align Selected Text" description="Align Selected Text" date="20150918200243"></plugin>
 	<plugin author="maestrith" name="Auto Insert" description="Auto Insert" date="20150906150745"></plugin>
 	<plugin author="maestrith" name="Camel" description="Camel Cases Selected Text" date="20150831001803"></plugin>
 	<plugin author="maestrith" name="Check For Update" description="Checks for updates to AHK Studio" date="20150822094401" version="1"></plugin>


### PR DESCRIPTION
Fixed:
- Lines with different indent levels weren't handled correctly
- Removed the "version=1" from index.xml. This plugin works with both
  versions of Studio
# 

**NOTE** - I did not update the date in the Index.xml
